### PR TITLE
Use nightly Yiipress build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Build documentation
         uses: yiipress/engine/.github/actions/build@master
+        with:
+          version: nightly
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- configure the Yiipress build action to use the nightly binary instead of its default latest release

## Testing
- not run; workflow config-only change